### PR TITLE
MAT-4439, Fix highlight scroll -Y

### DIFF
--- a/src/AceEditor/madie-ace-editor.tsx
+++ b/src/AceEditor/madie-ace-editor.tsx
@@ -65,7 +65,7 @@ export const mapParserErrorsToAceMarkers = (errors: CqlError[]) => {
 };
 
 const FooterDiv = tw.div`border border-gray-300 sm:text-sm`;
-
+// console.log('iace', IAceEditorProps)
 const MadieAceEditor = ({
   value,
   onChange,
@@ -182,6 +182,8 @@ const MadieAceEditor = ({
           onChange(value);
         }}
         onLoad={(aceEditor) => {
+          // On load we want to tell the ace editor that it's inside of a scrollabel page
+          aceEditor.setOption("autoScrollEditorIntoView", true);
           setEditor(aceEditor);
         }}
         width="100%"
@@ -190,7 +192,6 @@ const MadieAceEditor = ({
         readOnly={readOnly}
         name="ace-editor-wrapper"
         enableBasicAutocompletion={true}
-        editorProps={{ $blockScrolling: true }}
       />
       <FooterDiv>{renderFooterMsg()}</FooterDiv>
     </div>


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4439](https://jira.cms.gov/browse/MAT-4439)
(Optional) Related Tickets:

### Summary
Ace editor previously would not scroll downwards on the page if the window was small and the page sat high on the screen.
This bug was caused by AceEditor referring to screen position instead of relation to the document.

This pr just adds the config option to let it know what to listen to onLoad event.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is in to the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
