### PR TITLE
Exporting externalErrors with errorType include from elm translator

### DIFF
--- a/src/api/useElmTranslationServiceApi.ts
+++ b/src/api/useElmTranslationServiceApi.ts
@@ -15,6 +15,11 @@ export type ElmTranslationError = {
   type: string;
 };
 
+export interface ElmTranslationExternalError extends ElmTranslationError {
+  libraryId: string;
+  libraryVersion: string;
+}
+
 export type ElmTranslationLibrary = {
   annotation: any[];
   contexts: any;
@@ -35,12 +40,11 @@ export type ElmValueSet = {
 
 export type ElmTranslation = {
   errorExceptions: ElmTranslationError[];
-  externalErrors: any[];
+  externalErrors: ElmTranslationExternalError[];
   library: ElmTranslationLibrary;
 };
 
 export class ElmTranslationServiceApi {
-  //constructor(private getAccessToken: () => string) {}
   constructor(private baseUrl: string, private getAccessToken: () => string) {}
 
   async translateCqlToElm(cql: string): Promise<ElmTranslation> {

--- a/src/validations/codesystemValidation.ts
+++ b/src/validations/codesystemValidation.ts
@@ -69,11 +69,7 @@ const ValidateCustomCqlCodes = async (
 ): Promise<CustomCqlCode[]> => {
   const terminologyServiceApi = await useTerminologyServiceApi();
 
-  const result = terminologyServiceApi.validateCodes(
-    customCqlCodes,
-    loggedInUMLS
-  );
-  return result;
+  return terminologyServiceApi.validateCodes(customCqlCodes, loggedInUMLS);
 };
 
 export default ValidateCustomCqlCodes;

--- a/src/validations/elmTranslateValidation.ts
+++ b/src/validations/elmTranslateValidation.ts
@@ -1,15 +1,11 @@
-import React from "react";
 import useElmTranslationServiceApi, {
   ElmTranslation,
 } from "../api/useElmTranslationServiceApi";
-import * as _ from "lodash";
 
 const TranslateCql = async (cql: string): Promise<ElmTranslation> => {
   const elmTranslationServiceApi = await useElmTranslationServiceApi();
-  let translationResults = null;
   if (cql && cql.trim().length > 0) {
-    translationResults = await elmTranslationServiceApi.translateCqlToElm(cql);
-    return translationResults;
+    return await elmTranslationServiceApi.translateCqlToElm(cql);
   }
   return null;
 };


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4530](https://jira.cms.gov/browse/MAT-4530)
(Optional) Related Tickets:

### Summary

- useGetAllErrors function will be capturing external errors returned by the ELM translator and filter out the errors which are of type "include". 
- This particular error type "include" gives us information about any errors in included libraries, or if there are 2 or more different versions of the included library referred in a CQL (it also includes nested libraries )

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
