### PR TITLE
Add a conditional prop to pass outbound notifications outside the edi…

### DIFF
--- a/src/AceEditor/madie-ace-editor.tsx
+++ b/src/AceEditor/madie-ace-editor.tsx
@@ -22,6 +22,9 @@ export interface EditorPropsType {
   height?: string;
   readOnly?: boolean;
   validationsEnabled?: boolean;
+
+  // conditional props used to pass up annotations outside of the editor
+  setOutboundAnnotations?: Function;
 }
 
 export const parseEditorContent = (content): CqlError[] => {
@@ -158,6 +161,8 @@ const MadieAceEditor = ({
   inboundErrorMarkers,
   readOnly = false,
   validationsEnabled = true,
+
+  setOutboundAnnotations,
 }: EditorPropsType) => {
   const [editor, setEditor] = useState<any>();
   const [editorAnnotations, setEditorAnnotations] = useState<Ace.Annotation[]>(
@@ -166,6 +171,7 @@ const MadieAceEditor = ({
   const [parserAnnotations, setParserAnnotations] = useState<Ace.Annotation[]>(
     []
   );
+
   const [parseErrorMarkers, setParseErrorMarkers] = useState<Ace.MarkerLike[]>(
     []
   );
@@ -174,6 +180,10 @@ const MadieAceEditor = ({
 
   const customSetAnnotations = (annotations, editor) => {
     editor.getSession().setAnnotations(annotations);
+    // pass all the annotations we have out
+    if (setOutboundAnnotations) {
+      setOutboundAnnotations(annotations);
+    }
     setEditorAnnotations(annotations);
   };
 


### PR DESCRIPTION
The editor does not pass any internally derived annotations to its containing elements.
This PR adds a conditional function prop that does that so we can use it in external alert components

## MADiE PR

Jira Ticket: [MAT-4817](https://jira.cms.gov/browse/MAT-4817)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
