### PR TITLE
MAT-6389: enable valuesets, disable fields, update clear button function

### DIFF
--- a/src/terminologySectionPanel/TerminologySectionPanel.tsx
+++ b/src/terminologySectionPanel/TerminologySectionPanel.tsx
@@ -1,6 +1,4 @@
 import React, { useState } from "react";
-import KeyboardTabIcon from "@mui/icons-material/KeyboardTab";
-import { IconButton } from "@mui/material";
 import TerminologySectionPanelNavTabs from "./TerminologySectionPanelNavTabs";
 import ValueSetsSection from "./ValueSets/ValueSets";
 import CodesSection from "./codesSection/CodesSection";
@@ -25,7 +23,7 @@ export default function TerminologySectionPanel({ canEdit }) {
         />
       </div>
       <div className="panel-content">
-        {activeTab === "valueSets" && <ValueSetsSection />}
+        {activeTab === "valueSets" && <ValueSetsSection canEdit={canEdit} />}
         {activeTab === "codes" && <CodesSection canEdit={canEdit} />}
         {activeTab === "definitions" && <DefinitionsSection />}
       </div>

--- a/src/terminologySectionPanel/TerminologySectionPanelNavTabs.tsx
+++ b/src/terminologySectionPanel/TerminologySectionPanelNavTabs.tsx
@@ -27,7 +27,6 @@ export default function TerminologySectionPanelNavTabs(props: NavTabProps) {
           label="Value Sets"
           data-testid="valueSets-tab"
           value="valueSets"
-          disabled={!canEdit}
         />
       )}
       <Tab

--- a/src/terminologySectionPanel/ValueSets/ValueSets.test.tsx
+++ b/src/terminologySectionPanel/ValueSets/ValueSets.test.tsx
@@ -9,7 +9,7 @@ const { getByTestId, getByRole, getByText, queryByTestId, getByLabelText } =
   screen;
 describe("ValueSets Page", () => {
   it("Should not catch fire, should display all categories", () => {
-    render(<ValueSets />);
+    render(<ValueSets canEdit />);
     expect(getByTestId("madie-editor-value-sets")).toBeInTheDocument();
 
     expect(
@@ -23,7 +23,7 @@ describe("ValueSets Page", () => {
     ).toBeInTheDocument();
   });
   it("Should use a type ahead field to add and remove categories", async () => {
-    render(<ValueSets />);
+    render(<ValueSets canEdit />);
     const categoriesSelectButton = getByRole("button", {
       name: "Open",
     });
@@ -51,7 +51,7 @@ describe("ValueSets Page", () => {
   });
 
   it("Should enable submit button when a dynamic search field has text in it, should remove all values on clear", async () => {
-    render(<ValueSets />);
+    render(<ValueSets canEdit />);
     const categoriesSelectButton = getByRole("button", {
       name: "Open",
     });

--- a/src/terminologySectionPanel/ValueSets/ValueSets.tsx
+++ b/src/terminologySectionPanel/ValueSets/ValueSets.tsx
@@ -105,7 +105,7 @@ export default function ValueSets(props: ValueSetsProps) {
           id="search-by-category"
           label="Search By Category"
           required={false}
-          disabled={canEdit}
+          disabled={!canEdit}
           options={SEARCH_CATEGORIES}
           multipleSelect={true}
           limitTags={8}

--- a/src/terminologySectionPanel/ValueSets/ValueSets.tsx
+++ b/src/terminologySectionPanel/ValueSets/ValueSets.tsx
@@ -23,7 +23,11 @@ SEARCH_CATEGORIES.forEach((obj) => {
   SEARCH_MAP[obj.value] = obj.label;
 });
 
-export default function ValueSets() {
+interface ValueSetsProps {
+  canEdit: boolean;
+}
+export default function ValueSets(props: ValueSetsProps) {
+  const { canEdit } = props;
   const handleSearch = () => {};
 
   const formik = useFormik({
@@ -101,7 +105,7 @@ export default function ValueSets() {
           id="search-by-category"
           label="Search By Category"
           required={false}
-          disabled={false}
+          disabled={canEdit}
           options={SEARCH_CATEGORIES}
           multipleSelect={true}
           limitTags={8}

--- a/src/terminologySectionPanel/codesSection/codesSubSection/codeSubSection/CodeSection.tsx
+++ b/src/terminologySectionPanel/codesSection/codesSubSection/codeSubSection/CodeSection.tsx
@@ -21,6 +21,7 @@ interface CodeSectionProps {
   handleFormSubmit: Function;
   canEdit: boolean;
   allCodeSystems: CodeSystem[];
+  blankResults: Function;
 }
 
 interface MenuObj {
@@ -32,6 +33,7 @@ export default function CodeSection({
   handleFormSubmit,
   allCodeSystems,
   canEdit,
+  blankResults,
 }: CodeSectionProps) {
   const [titles, setTitles] = useState([]);
   // if we open tab before information has arrived, we need to trigger a useEffect
@@ -195,7 +197,10 @@ export default function CodeSection({
                   data-testid="clear-codes-btn"
                   disabled={!formik.dirty || !canEdit}
                   tw="mr-4"
-                  onClick={resetForm}
+                  onClick={() => {
+                    resetForm();
+                    blankResults();
+                  }}
                 >
                   Clear
                 </Button>

--- a/src/terminologySectionPanel/codesSection/codesSubSection/codeSubSection/CodeSubSection.tsx
+++ b/src/terminologySectionPanel/codesSection/codesSubSection/codeSubSection/CodeSubSection.tsx
@@ -51,12 +51,18 @@ export default function CodeSubSection({
     }
   };
 
+  const blankResults = () => {
+    setShowResultsTable(false);
+    setCode(undefined);
+  };
+
   return (
     <>
       <CodeSection
         handleFormSubmit={handleFormSubmit}
         allCodeSystems={allCodeSystems}
         canEdit={canEdit}
+        blankResults={blankResults}
       />
       <ResultsSection
         showResultsTable={showResultsTable}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6389](https://jira.cms.gov/browse/MAT-6389)
(Optional) Related Tickets:
Jira Ticket: [MAT-6917](https://jira.cms.gov/browse/MAT-6917)

### Summary

This PR: 
* enables valuesets tab under all conditions. Disables forms inside valueSets page.
* adds functionality to clear button for removing the results table and not just blanking the form elements. ( codes section_ 

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is in to the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
