### PR TITLE
[MAT-7316] Disable Definition fields when user does not have canEdit privs

### DIFF
--- a/src/CqlBuilderPanel/CqlBuilderPanel.tsx
+++ b/src/CqlBuilderPanel/CqlBuilderPanel.tsx
@@ -54,7 +54,9 @@ export default function CqlBuilderPanel({
             handleApplyCode={handleApplyCode}
           />
         )}
-        {activeTab === "definitions" && <DefinitionsSection canEdit />}
+        {activeTab === "definitions" && (
+          <DefinitionsSection canEdit={canEdit} />
+        )}
       </div>
     </div>
   );

--- a/src/CqlBuilderPanel/definitionsSection/DefinitionSection.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/DefinitionSection.tsx
@@ -49,7 +49,7 @@ export default function DefinitionSection({ canEdit }: DefinitionProps) {
             name="definitionName"
             tw="w-full"
             readOnly={!canEdit}
-            // disabled={!canEdit}
+            disabled={!canEdit}
             label="Definition Name"
             placeholder=""
             inputProps={{
@@ -67,6 +67,7 @@ export default function DefinitionSection({ canEdit }: DefinitionProps) {
           tw="w-full"
           label="Comment"
           readOnly={!canEdit}
+          disabled={!canEdit}
           placeholder=""
           inputProps={{
             "data-testid": "definition-comment-text-input",


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7316](https://jira.cms.gov/browse/MAT-7316)
(Optional) Related Tickets:

### Summary

Correctly pass the `canEdit` prop such that the disabled props work as expected.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
