### PR TITLE
MAT-7405 refactor cql definition builder UI

### DIFF
--- a/src/AceEditor/madie-ace-editor.tsx
+++ b/src/AceEditor/madie-ace-editor.tsx
@@ -17,7 +17,7 @@ import {
   CqlMetaData,
   ValueSetForSearch,
 } from "../api/useTerminologyServiceApi";
-import { Definition } from "../CqlBuilderPanel/definitionsSection/DefinitionSection";
+import { Definition } from "../CqlBuilderPanel/definitionsSection/definitionBuilder/DefinitionBuilder";
 import { SelectedLibrary } from "../CqlBuilderPanel/Includes/CqlLibraryDetailsDialog";
 
 export interface EditorPropsType {

--- a/src/CqlBuilderPanel/definitionsSection/DefinitionSectionNavTabs.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/DefinitionSectionNavTabs.tsx
@@ -33,11 +33,11 @@ export default function DefinitionSectionNavTabs(props: NavTabProps) {
         />
         <Tab
           tabIndex={0}
-          aria-label={`Saved Definition(s)`}
+          aria-label="Saved Definitions"
           type="B"
-          label={`Saved Definition(s) (${definitionCount})`}
-          data-testid="savedDefinitions-tab"
-          value="savedDefinitions"
+          label={`Saved Definitions (${definitionCount})`}
+          data-testid="saved-definitions-tab"
+          value="saved-definitions"
         />
       </Tabs>
     </div>

--- a/src/CqlBuilderPanel/definitionsSection/DefinitionsSection.test.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/DefinitionsSection.test.tsx
@@ -4,7 +4,7 @@ import DefinitionsSection from "./DefinitionsSection";
 import userEvent from "@testing-library/user-event";
 import { CqlBuilderLookupData } from "../../model/CqlBuilderLookup";
 
-describe("DefinitionSection", () => {
+describe("DefinitionsSection", () => {
   const cqlBuilderData = {
     parameters: ["TJC.Measurement Period", "Global.Measurement Period"],
     definitions: [
@@ -35,11 +35,14 @@ describe("DefinitionSection", () => {
       <DefinitionsSection
         canEdit={true}
         handleApplyDefinition={jest.fn()}
-        cqlBuilderLookupsTypes={{} as unknown as CqlBuilderLookupData}
+        cqlBuilderLookupsTypes={{} as CqlBuilderLookupData}
+        handleDefinitionDelete={jest.fn()}
+        isCQLUnchanged
+        setIsCQLUnchanged
       />
     );
     const definition = await screen.findByTestId("definition-tab");
-    const savedDefinitions = await screen.findByText("Saved Definition(s) (0)");
+    const savedDefinitions = await screen.findByText("Saved Definitions (0)");
     expect(definition).toBeInTheDocument();
     expect(savedDefinitions).toBeInTheDocument();
     await waitFor(() => {
@@ -55,11 +58,14 @@ describe("DefinitionSection", () => {
       <DefinitionsSection
         canEdit={true}
         handleApplyDefinition={jest.fn()}
-        cqlBuilderLookupsTypes={{} as unknown as CqlBuilderLookupData}
+        cqlBuilderLookupsTypes={{} as CqlBuilderLookupData}
+        handleDefinitionDelete={jest.fn()}
+        isCQLUnchanged
+        setIsCQLUnchanged
       />
     );
     const definition = await screen.findByTestId("definition-tab");
-    const savedDefinitions = await screen.findByText("Saved Definition(s) (0)");
+    const savedDefinitions = await screen.findByText("Saved Definitions (0)");
     expect(definition).toBeInTheDocument();
     expect(savedDefinitions).toBeInTheDocument();
     await waitFor(() => {
@@ -80,10 +86,13 @@ describe("DefinitionSection", () => {
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderData}
+        handleDefinitionDelete={jest.fn()}
+        isCQLUnchanged
+        setIsCQLUnchanged
       />
     );
     const definition = await screen.findByTestId("definition-tab");
-    const savedDefinitions = await screen.findByText("Saved Definition(s) (9)");
+    const savedDefinitions = await screen.findByText("Saved Definitions (9)");
     expect(definition).toBeInTheDocument();
     expect(savedDefinitions).toBeInTheDocument();
     await waitFor(() => {
@@ -117,10 +126,13 @@ describe("DefinitionSection", () => {
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderData}
+        handleDefinitionDelete={jest.fn()}
+        isCQLUnchanged
+        setIsCQLUnchanged
       />
     );
     const definition = await screen.findByTestId("definition-tab");
-    const savedDefinitions = await screen.findByText("Saved Definition(s) (9)");
+    const savedDefinitions = await screen.findByText("Saved Definitions (9)");
     expect(definition).toBeInTheDocument();
     expect(savedDefinitions).toBeInTheDocument();
     await waitFor(() => {

--- a/src/CqlBuilderPanel/definitionsSection/DefinitionsSection.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/DefinitionsSection.tsx
@@ -1,28 +1,9 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
-import tw from "twin.macro";
-import "styled-components/macro";
+import React, { useState } from "react";
 import "./Definitions.scss";
 import DefinitionSectionNavTabs from "./DefinitionSectionNavTabs";
-import DefinitionSection from "./DefinitionSection";
 import { CqlBuilderLookupData } from "../../model/CqlBuilderLookup";
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-  ColumnDef,
-  RowModel,
-} from "@tanstack/react-table";
-import _ from "lodash";
-
-import {
-  Pagination,
-  Popover,
-  MadieSpinner,
-} from "@madie/madie-design-system/dist/react";
-import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
-import EditNoteRoundedIcon from "@mui/icons-material/EditNoteRounded";
-import { green } from "@mui/material/colors";
+import Definitions from "./definitions/Definitions";
+import DefinitionBuilder from "./definitionBuilder/DefinitionBuilder";
 interface DefinitionProps {
   canEdit: boolean;
   handleApplyDefinition: Function;
@@ -31,157 +12,18 @@ interface DefinitionProps {
   setIsCQLUnchanged: boolean;
   isCQLUnchanged: boolean;
 }
-
 export type Definition = {
   id: number;
   name: string;
   comment: string;
 };
 
-const columnHelper = createColumnHelper<Definition>();
-const TH = tw.th`p-3 text-left text-sm font-bold capitalize`;
-const TD = tw.td`p-3 text-left text-sm break-all`;
-
 export default function DefinitionsSection({
   canEdit,
   handleApplyDefinition,
-  handleDefinitionDelete,
   cqlBuilderLookupsTypes,
-  setIsCQLUnchanged,
-  isCQLUnchanged,
 }: DefinitionProps) {
   const [activeTab, setActiveTab] = useState<string>("definition");
-  const [optionsOpen, setOptionsOpen] = useState<boolean>(false);
-  const [anchorEl, setAnchorEl] = useState(null);
-  const [selectedReferenceId, setSelectedReferenceId] = useState<string>(null);
-  const [selectedDefintion, setSelectedDefinition] = useState<Definition>(null);
-  const [totalPages, setTotalPages] = useState<number>(0);
-  const [totalItems, setTotalItems] = useState<number>(0);
-  const [visibleItems, setVisibleItems] = useState<number>(0);
-  const [visibleDefinitions, setVisibleDefinitions] = useState<Definition[]>(
-    []
-  );
-  const [loading, setLoading] = useState<boolean>(false);
-
-  const [offset, setOffset] = useState<number>(0);
-  const [currentLimit, setCurrentLimit] = useState<number>(5);
-  const [currentPage, setCurrentPage] = useState<number>(1);
-
-  const [discardDialogOpen, setDiscardDialogOpen] = useState<boolean>(false);
-  const [deleteDialogModalOpen, setDeleteDialogModalOpen] =
-    useState<boolean>(false);
-  const canGoPrev = currentPage > 1;
-  const canGoNext = (() => {
-    return currentPage < totalPages;
-  })();
-  const handlePageChange = (e, v) => {
-    setCurrentPage(v);
-  };
-  const handleLimitChange = (e) => {
-    setCurrentLimit(e.target.value);
-    setCurrentPage(1);
-  };
-
-  const handleOpen = async (
-    selectedId,
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    setOptionsOpen(true);
-    setAnchorEl(event.currentTarget);
-
-    setSelectedDefinition(table.getRow(selectedId).original);
-  };
-
-  const handleClose = () => {
-    setOptionsOpen(false);
-
-    setAnchorEl(null);
-  };
-  useEffect(() => {
-    managePagination();
-  }, [cqlBuilderLookupsTypes, currentPage, currentLimit]);
-
-  // table data
-  const data = visibleDefinitions?.map((definition) => {
-    return {
-      name: definition.name,
-      comment: definition.comment,
-    } as unknown as Definition;
-  });
-  const columns = useMemo<ColumnDef<Definition>[]>(
-    () => [
-      {
-        header: "Name",
-        accessorKey: "name",
-      },
-      {
-        header: "Comment",
-        accessorKey: "comment",
-      },
-      {
-        header: "",
-        accessorKey: "apply",
-        cell: (row: any) => {
-          return (
-            <>
-              <button onClick={(e) => handleOpen(row.cell.row.id, e)}>
-                <DeleteOutlineOutlinedIcon htmlColor="red" />
-              </button>
-              <EditNoteRoundedIcon color="primary" />
-            </>
-          );
-        },
-      },
-    ],
-    [cqlBuilderLookupsTypes]
-  );
-
-  const table = useReactTable({
-    data,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
-  const managePagination = useCallback(() => {
-    let definitions;
-    if (cqlBuilderLookupsTypes?.definitions) {
-      definitions = cqlBuilderLookupsTypes?.definitions.map((definition) => {
-        return {
-          name: definition,
-          comment: "",
-        } as unknown as Definition;
-      });
-    } else {
-      definitions = {} as unknown as Definition;
-    }
-
-    if (definitions?.length > 0) {
-      setTotalItems(definitions.length);
-      if (definitions.length < currentLimit) {
-        setOffset(0);
-        setVisibleDefinitions(definitions && [...definitions]);
-        setVisibleItems(definitions?.length);
-        setTotalPages(1);
-      } else {
-        const start = (currentPage - 1) * currentLimit;
-        const end = start + currentLimit;
-        const newVisibleCodes = [...definitions].slice(start, end);
-        setOffset(start);
-        setVisibleDefinitions(newVisibleCodes);
-        setVisibleItems(newVisibleCodes?.length);
-        setTotalPages(Math.ceil(definitions?.length / currentLimit));
-      }
-    }
-  }, [
-    currentLimit,
-    currentPage,
-    cqlBuilderLookupsTypes,
-    setOffset,
-    setVisibleDefinitions,
-    setVisibleItems,
-    setTotalItems,
-    setTotalPages,
-  ]);
 
   return (
     <>
@@ -198,113 +40,14 @@ export default function DefinitionsSection({
       />
       <div>
         {activeTab === "definition" && (
-          <DefinitionSection
+          <DefinitionBuilder
             canEdit={canEdit}
             handleApplyDefinition={handleApplyDefinition}
             cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}
           />
         )}
-        {activeTab === "savedDefinitions" && (
-          <>
-            <table
-              tw="min-w-full"
-              data-testid="saved-definitions-tbl"
-              id="saved-definitions-tbl"
-              style={{
-                borderBottom: "solid 1px #8c8c8c",
-              }}
-            >
-              <thead tw="bg-slate">
-                {table.getHeaderGroups()?.map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers?.map((header) => (
-                      <TH key={header.id} scope="col">
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                      </TH>
-                    ))}
-                  </tr>
-                ))}
-              </thead>
-              <tbody data-testid="saved-definitions-table-body">
-                {!loading ? (
-                  _.isEmpty(cqlBuilderLookupsTypes?.definitions) ? (
-                    <tr>
-                      <td colSpan={columns.length} tw="text-center p-2">
-                        No Results were found
-                      </td>
-                    </tr>
-                  ) : (
-                    table.getRowModel().rows.map((row) => (
-                      <tr
-                        key={row.id}
-                        data-testid={`saved-definitions-row-${row.id}`}
-                      >
-                        {row.getVisibleCells().map((cell) => (
-                          <TD key={cell.id}>
-                            {flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext()
-                            )}
-                          </TD>
-                        ))}
-                      </tr>
-                    ))
-                  )
-                ) : (
-                  <div data-testid="saved-codes-loading-spinner">
-                    <MadieSpinner style={{ height: 50, width: 50 }} />
-                  </div>
-                )}
-              </tbody>
-
-              <Popover
-                optionsOpen={optionsOpen}
-                anchorEl={anchorEl}
-                handleClose={handleClose}
-                canEdit={true}
-                editViewSelectOptionProps={{
-                  label: "Remove",
-                  toImplementFunction: () => {
-                    setOptionsOpen(false);
-                    if (!isCQLUnchanged) {
-                      setDiscardDialogOpen(true);
-                    } else {
-                      setDeleteDialogModalOpen(true);
-                    }
-                  },
-                  dataTestId: `remove-code-${selectedReferenceId}`,
-                }}
-                otherSelectOptionProps={[
-                  {
-                    label: "Edit",
-                    toImplementFunction: () => {},
-                    dataTestId: `edit-code-${selectedReferenceId}`,
-                  },
-                ]}
-              />
-            </table>
-            <div className="pagination-container">
-              <Pagination
-                totalItems={totalItems}
-                visibleItems={visibleItems}
-                limitOptions={[5, 10, 25, 50]}
-                offset={offset}
-                handlePageChange={handlePageChange}
-                handleLimitChange={handleLimitChange}
-                page={currentPage}
-                limit={currentLimit}
-                count={totalPages}
-                shape="rounded"
-                hideNextButton={!canGoNext}
-                hidePrevButton={!canGoPrev}
-              />
-            </div>
-          </>
+        {activeTab === "saved-definitions" && (
+          <Definitions definitions={cqlBuilderLookupsTypes?.definitions} />
         )}
       </div>
     </>

--- a/src/CqlBuilderPanel/definitionsSection/definitionBuilder/DefinitionBuilder.test.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/definitionBuilder/DefinitionBuilder.test.tsx
@@ -1,24 +1,15 @@
 import * as React from "react";
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it } from "@jest/globals";
 import "@testing-library/jest-dom";
-import DefinitionsSection from "./DefinitionsSection";
 import { within } from "@testing-library/dom";
-import { cqlBuilderLookupsTypes } from "../__mocks__/MockCqlBuilderLookupsTypes";
-import { formatExpressionName } from "./DefinitionSection";
+import DefinitionBuilder, { formatExpressionName } from "./DefinitionBuilder";
+import { cqlBuilderLookupsTypes } from "../../__mocks__/MockCqlBuilderLookupsTypes";
 
-const mockEditor = { resize: jest.fn() };
-
-describe("CQL Definition Builder Section", () => {
+describe("CQL Definition Builder Tests", () => {
   it("Should display name and comment fields", async () => {
     render(
-      <DefinitionsSection
+      <DefinitionBuilder
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}
@@ -40,9 +31,9 @@ describe("CQL Definition Builder Section", () => {
     expect(screen.queryByTestId("type-selector-input")).not.toBeInTheDocument();
   });
 
-  it("Should disable Apply buton with canEdit being false", async () => {
+  it("Should disable Apply button with canEdit being false", async () => {
     render(
-      <DefinitionsSection
+      <DefinitionBuilder
         canEdit={false}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}
@@ -60,7 +51,7 @@ describe("CQL Definition Builder Section", () => {
 
   it("Should open Expression Editor when definition name is entered", async () => {
     render(
-      <DefinitionsSection
+      <DefinitionBuilder
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}
@@ -89,7 +80,7 @@ describe("CQL Definition Builder Section", () => {
 
   it("Should should clear value when clear button is clicked", async () => {
     render(
-      <DefinitionsSection
+      <DefinitionBuilder
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}
@@ -123,7 +114,7 @@ describe("CQL Definition Builder Section", () => {
 
   it("Should populate name dropdown list", async () => {
     render(
-      <DefinitionsSection
+      <DefinitionBuilder
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}
@@ -181,7 +172,7 @@ describe("CQL Definition Builder Section", () => {
 
   it("should enable insert button", async () => {
     render(
-      <DefinitionsSection
+      <DefinitionBuilder
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}
@@ -242,7 +233,7 @@ describe("CQL Definition Builder Section", () => {
 
   it("expression is inserted into text area when insert button is clicked", async () => {
     render(
-      <DefinitionsSection
+      <DefinitionBuilder
         canEdit={true}
         handleApplyDefinition={jest.fn()}
         cqlBuilderLookupsTypes={cqlBuilderLookupsTypes}

--- a/src/CqlBuilderPanel/definitionsSection/definitionBuilder/DefinitionBuilder.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/definitionBuilder/DefinitionBuilder.tsx
@@ -7,10 +7,10 @@ import {
   TextField,
   Button,
 } from "@madie/madie-design-system/dist/react";
-import "./Definitions.scss";
-import { DefinitionSectionSchemaValidator } from "../../validations/DefinitionSectionSchemaValidator";
-import ExpressionEditor from "./expressionSection/ExpressionEditor";
-import { CqlBuilderLookupData } from "../../model/CqlBuilderLookup";
+import "../Definitions.scss";
+import { DefinitionSectionSchemaValidator } from "../../../validations/DefinitionSectionSchemaValidator";
+import ExpressionEditor from "../expressionSection/ExpressionEditor";
+import { CqlBuilderLookupData } from "../../../model/CqlBuilderLookup";
 
 export interface Definition {
   definitionName?: string;
@@ -34,7 +34,7 @@ export const formatExpressionName = (values) => {
     : values?.name;
 };
 
-export default function DefinitionSection({
+export default function DefinitionBuilder({
   canEdit,
   handleApplyDefinition,
   cqlBuilderLookupsTypes,

--- a/src/CqlBuilderPanel/definitionsSection/definitions/Definitions.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/definitions/Definitions.tsx
@@ -1,0 +1,201 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import tw from "twin.macro";
+import "styled-components/macro";
+import { Pagination } from "@madie/madie-design-system/dist/react";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import BorderColorOutlinedIcon from "@mui/icons-material/BorderColorOutlined";
+import ToolTippedIcon from "../../../toolTippedIcon/ToolTippedIcon";
+import { Definition } from "../DefinitionsSection";
+
+const TH = tw.th`p-3 text-left text-sm font-bold capitalize`;
+const TD = tw.td`p-3 text-left text-sm break-all`;
+
+const Definitions = ({ definitions }: { definitions: string[] }) => {
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [totalItems, setTotalItems] = useState<number>(0);
+  const [visibleItems, setVisibleItems] = useState<number>(0);
+  const [visibleDefinitions, setVisibleDefinitions] = useState<Definition[]>(
+    []
+  );
+
+  const allRowDefinitions = definitions?.map((definition) => {
+    return {
+      name: definition,
+      comment: "",
+    } as Definition;
+  });
+
+  const [offset, setOffset] = useState<number>(0);
+  const [currentLimit, setCurrentLimit] = useState<number>(5);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  const canGoPrev = currentPage > 1;
+  const canGoNext = (() => {
+    return currentPage < totalPages;
+  })();
+  const handlePageChange = (e, v) => {
+    setCurrentPage(v);
+  };
+  const handleLimitChange = (e) => {
+    setCurrentLimit(e.target.value);
+    setCurrentPage(1);
+  };
+
+  useEffect(() => {
+    managePagination();
+  }, [definitions, currentPage, currentLimit]);
+
+  // table data
+  const data = visibleDefinitions?.map((definition) => {
+    return {
+      name: definition.name,
+      comment: definition.comment,
+    } as unknown as Definition;
+  });
+
+  const columns = useMemo<ColumnDef<Definition>[]>(
+    () => [
+      {
+        header: "Name",
+        accessorKey: "name",
+      },
+      {
+        header: "Comment",
+        accessorKey: "comment",
+      },
+      {
+        header: "",
+        accessorKey: "apply",
+        cell: (row: any) => {
+          return (
+            <>
+              <ToolTippedIcon
+                tooltipMessage="Delete"
+                buttonProps={{
+                  "data-testid": `delete-button-${row.cell.row.id}`,
+                  "aria-label": `delete-button-${row.cell.row.id}`,
+                  size: "small",
+                  onClick: () => {}, // do nothing for now
+                }}
+              >
+                <DeleteOutlineIcon color="error" />
+              </ToolTippedIcon>
+              <ToolTippedIcon
+                tooltipMessage="Edit"
+                buttonProps={{
+                  "data-testid": `edit-button-${row.cell.row.id}`,
+                  "aria-label": `edit-button-${row.cell.row.id}`,
+                  size: "small",
+                  onClick: () => {},
+                }}
+              >
+                <BorderColorOutlinedIcon color="primary" />
+              </ToolTippedIcon>
+            </>
+          );
+        },
+      },
+    ],
+    [definitions]
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const managePagination = useCallback(() => {
+    if (allRowDefinitions?.length > 0) {
+      setTotalItems(definitions.length);
+      if (definitions.length < currentLimit) {
+        setOffset(0);
+        setVisibleDefinitions(allRowDefinitions && [...allRowDefinitions]);
+        setVisibleItems(definitions?.length);
+        setTotalPages(1);
+      } else {
+        const start = (currentPage - 1) * currentLimit;
+        const end = start + currentLimit;
+        const newVisibleCodes = [...allRowDefinitions].slice(start, end);
+        setOffset(start);
+        setVisibleDefinitions(newVisibleCodes);
+        setVisibleItems(newVisibleCodes?.length);
+        setTotalPages(Math.ceil(definitions?.length / currentLimit));
+      }
+    }
+  }, [
+    currentLimit,
+    currentPage,
+    definitions,
+    setOffset,
+    setVisibleDefinitions,
+    setVisibleItems,
+    setTotalItems,
+    setTotalPages,
+  ]);
+
+  return (
+    <>
+      <table
+        tw="min-w-full"
+        data-testid="definitions-tbl"
+        id="definitions-tbl"
+        style={{
+          borderBottom: "solid 1px #8c8c8c",
+        }}
+      >
+        <thead tw="bg-slate">
+          {table.getHeaderGroups()?.map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers?.map((header) => (
+                <TH key={header.id} scope="col">
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                </TH>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody data-testid="definitions-table-body">
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id} data-testid={`definitions-row-${row.id}`}>
+              {row.getVisibleCells().map((cell) => (
+                <TD key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TD>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="pagination-container">
+        <Pagination
+          totalItems={totalItems}
+          visibleItems={visibleItems}
+          limitOptions={[5, 10, 25, 50]}
+          offset={offset}
+          handlePageChange={handlePageChange}
+          handleLimitChange={handleLimitChange}
+          page={currentPage}
+          limit={currentLimit}
+          count={totalPages}
+          shape="rounded"
+          hideNextButton={!canGoNext}
+          hidePrevButton={!canGoPrev}
+        />
+      </div>
+    </>
+  );
+};
+
+export default Definitions;

--- a/src/CqlBuilderPanel/definitionsSection/expressionSection/ExpressionEditor.tsx
+++ b/src/CqlBuilderPanel/definitionsSection/expressionSection/ExpressionEditor.tsx
@@ -14,9 +14,8 @@ import {
 } from "./ExpressionEditorHelper";
 import * as _ from "lodash";
 import { CqlBuilderLookupData } from "../../../model/CqlBuilderLookup";
-import { Definition } from "../DefinitionSection";
+import { Definition } from "../definitionBuilder/DefinitionBuilder";
 import AceEditor from "react-ace";
-import { Ace } from "ace-builds";
 
 interface ExpressionsProps {
   canEdit: boolean;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7405](https://jira.cms.gov/browse/MAT-7405)
(Optional) Related Tickets:

### Summary
- Refactored definition UI builder components, and introduced a component to display saved definitions
-  This will help reuse some code in the edit definition action

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
