### PR TITLE
MAT-8215 Updated Saved CQL UI builders tabs to not display contents w…

### DIFF
--- a/src/AceEditor/madie-ace-editor.tsx
+++ b/src/AceEditor/madie-ace-editor.tsx
@@ -67,6 +67,7 @@ export interface EditorPropsType {
   getCqlDefinitionReturnTypes?: () => void;
   // conditional props used to pass up annotations outside of the editor
   setOutboundAnnotations?: Function;
+  hasCqlError?: boolean;
 }
 
 export interface UpdatedCqlObject {

--- a/src/CqlBuilderPanel/CqlBuilderPanel.test.tsx
+++ b/src/CqlBuilderPanel/CqlBuilderPanel.test.tsx
@@ -129,6 +129,7 @@ const props = {
   editorVal: undefined,
   handleFunctionDelete: undefined,
   handleFunctionEdit: undefined,
+  hasCqlError: false,
 };
 const { getByTestId } = screen;
 
@@ -645,7 +646,7 @@ describe("CqlBuilderPanel", () => {
       data: mockCqlBuilderLookUpData,
     });
     render(<CqlBuilderPanel {...props} />);
-    const parameterTab = await screen.queryByText("Parameters");
+    const parameterTab = screen.queryByText("Parameters");
     expect(parameterTab).not.toBeInTheDocument();
   });
 
@@ -660,7 +661,7 @@ describe("CqlBuilderPanel", () => {
       data: mockCqlBuilderLookUpData,
     });
     render(<CqlBuilderPanel {...newProps} />);
-    const parameterTab = await screen.queryByText("Parameters");
+    const parameterTab = screen.queryByText("Parameters");
     expect(parameterTab).toBeInTheDocument();
     expect(parameterTab).toBeEnabled();
   });
@@ -675,12 +676,12 @@ describe("CqlBuilderPanel", () => {
       data: mockCqlBuilderLookUpData,
     });
     let result = render(<CqlBuilderPanel {...props} />);
-    const parameterTab = await screen.queryByText("Parameters");
+    const parameterTab = screen.queryByText("Parameters");
     expect(parameterTab).toBeInTheDocument();
     userEvent.click(screen.getByRole("tab", { name: "Parameters" }));
     expect(screen.getByTestId("cql-editor-parameters")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId("saved-parameters-tab"));
+    userEvent.click(screen.getByTestId("saved-parameters-tab"));
 
     await waitFor(() => {
       expect(screen.getByTestId("saved-parameters-tab")).toHaveAttribute(
@@ -690,7 +691,7 @@ describe("CqlBuilderPanel", () => {
     });
     expect(screen.getByTestId("saved-parameters")).toBeInTheDocument();
     // switch back
-    await userEvent.click(screen.getByTestId("parameter-tab"));
+    userEvent.click(screen.getByTestId("parameter-tab"));
     await waitFor(() => {
       expect(screen.getByTestId("parameter-tab")).toHaveAttribute(
         "aria-selected",
@@ -726,6 +727,7 @@ describe("CqlBuilderPanel", () => {
       expect(aceEditor.value).toContain("");
     });
   });
+
   it("Parameters apply works and clears input fields", async () => {
     useFeatureFlags.mockImplementationOnce(() => ({
       QDMValueSetSearch: true,
@@ -740,12 +742,12 @@ describe("CqlBuilderPanel", () => {
     applyParameter.mockReturnValue("success");
     const copiedProps = { ...props, handleApplyParameter: applyParameter };
     let result = render(<CqlBuilderPanel {...copiedProps} />);
-    const parameterTab = await screen.queryByText("Parameters");
+    const parameterTab = screen.queryByText("Parameters");
     expect(parameterTab).toBeInTheDocument();
     userEvent.click(screen.getByRole("tab", { name: "Parameters" }));
     expect(screen.getByTestId("cql-editor-parameters")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId("saved-parameters-tab"));
+    userEvent.click(screen.getByTestId("saved-parameters-tab"));
 
     await waitFor(() => {
       expect(screen.getByTestId("saved-parameters-tab")).toHaveAttribute(
@@ -755,7 +757,7 @@ describe("CqlBuilderPanel", () => {
     });
     expect(screen.getByTestId("saved-parameters")).toBeInTheDocument();
     // switch back
-    await userEvent.click(screen.getByTestId("parameter-tab"));
+    userEvent.click(screen.getByTestId("parameter-tab"));
     await waitFor(() => {
       expect(screen.getByTestId("parameter-tab")).toHaveAttribute(
         "aria-selected",
@@ -795,6 +797,7 @@ describe("CqlBuilderPanel", () => {
       expect(aceEditor.value).toContain("");
     });
   });
+
   it("Parameters apply did not work, fields did not get updated", async () => {
     useFeatureFlags.mockImplementationOnce(() => ({
       QDMValueSetSearch: true,
@@ -809,12 +812,12 @@ describe("CqlBuilderPanel", () => {
     applyParameter.mockReturnValue("failure");
     const copiedProps = { ...props, handleApplyParameter: applyParameter };
     let result = render(<CqlBuilderPanel {...copiedProps} />);
-    const parameterTab = await screen.queryByText("Parameters");
+    const parameterTab = screen.queryByText("Parameters");
     expect(parameterTab).toBeInTheDocument();
     userEvent.click(screen.getByRole("tab", { name: "Parameters" }));
     expect(screen.getByTestId("cql-editor-parameters")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId("saved-parameters-tab"));
+    userEvent.click(screen.getByTestId("saved-parameters-tab"));
 
     await waitFor(() => {
       expect(screen.getByTestId("saved-parameters-tab")).toHaveAttribute(
@@ -824,7 +827,7 @@ describe("CqlBuilderPanel", () => {
     });
     expect(screen.getByTestId("saved-parameters")).toBeInTheDocument();
     // switch back
-    await userEvent.click(screen.getByTestId("parameter-tab"));
+    userEvent.click(screen.getByTestId("parameter-tab"));
     await waitFor(() => {
       expect(screen.getByTestId("parameter-tab")).toHaveAttribute(
         "aria-selected",
@@ -877,7 +880,7 @@ describe("CqlBuilderPanel", () => {
       data: mockCqlBuilderLookUpData,
     });
     render(<CqlBuilderPanel {...newProps} />);
-    const parameterTab = await screen.queryByText("Functions");
+    const parameterTab = screen.queryByText("Functions");
     expect(parameterTab).toBeInTheDocument();
     expect(parameterTab).toBeEnabled();
   });
@@ -893,7 +896,16 @@ describe("CqlBuilderPanel", () => {
       data: mockCqlBuilderLookUpData,
     });
     render(<CqlBuilderPanel {...props} />);
-    const parameterTab = await screen.queryByText("Functions");
+    const parameterTab = screen.queryByText("Functions");
     expect(parameterTab).not.toBeInTheDocument();
+  });
+
+  it("Should display error text when CQL has errors", async () => {
+    const newProps = { ...props, hasCqlError: true };
+    render(<CqlBuilderPanel {...newProps} />);
+    const errorMessage = await screen.findByRole("alert");
+    expect(errorMessage).toHaveTextContent(
+      "Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk."
+    );
   });
 });

--- a/src/CqlBuilderPanel/CqlBuilderPanel.tsx
+++ b/src/CqlBuilderPanel/CqlBuilderPanel.tsx
@@ -42,6 +42,7 @@ export default function CqlBuilderPanel({
   resetCql,
   getCqlDefinitionReturnTypes,
   makeExpanded,
+  hasCqlError,
 }) {
   const featureFlags = useFeatureFlags();
   const {
@@ -69,65 +70,72 @@ export default function CqlBuilderPanel({
 
   useEffect(() => {
     if (measureStoreCql && measureStoreCql.trim().length > 0) {
-      if (measureModel?.includes("QDM")) {
-        qdmElmTranslationServiceApi
-          .then((qdmElmTranslationServiceApi) => {
-            qdmElmTranslationServiceApi
-              .getCqlBuilderLookups(measureStoreCql)
-              .then((axiosResponse: AxiosResponse<CqlBuilderLookup>) => {
-                setErrors(null);
-                setCqlBuilderLookupsTypes(axiosResponse?.data);
-              })
-              .catch((error) => {
-                setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
-
-                setErrors(
-                  "Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk."
-                );
-                console.error(error);
-              })
-              .finally(() => {
-                setLoading(false);
-              });
-          })
-          .catch((error) => {
-            setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
-
-            setErrors(
-              "Unable to retrieve Service Config, Please try again or contact Helpdesk"
-            );
-            console.error(error);
-            setLoading(false);
-          });
+      if (hasCqlError) {
+        setErrors(
+          "Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk."
+        );
+        setLoading(false);
       } else {
-        fhirElmTranslationServiceApi
-          .then((fhirElmTranslationServiceApi) => {
-            fhirElmTranslationServiceApi
-              .getCqlBuilderLookups(measureStoreCql)
-              .then((axiosResponse: AxiosResponse<CqlBuilderLookup>) => {
-                setCqlBuilderLookupsTypes(axiosResponse?.data);
-              })
-              .catch((error) => {
-                setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
+        if (measureModel?.includes("QDM")) {
+          qdmElmTranslationServiceApi
+            .then((qdmElmTranslationServiceApi) => {
+              qdmElmTranslationServiceApi
+                .getCqlBuilderLookups(measureStoreCql)
+                .then((axiosResponse: AxiosResponse<CqlBuilderLookup>) => {
+                  setErrors(null);
+                  setCqlBuilderLookupsTypes(axiosResponse?.data);
+                })
+                .catch((error) => {
+                  setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
 
-                setErrors(
-                  "Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk."
-                );
-                console.error(error);
-              })
-              .finally(() => {
-                setLoading(false);
-              });
-          })
-          .catch((error) => {
-            setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
+                  setErrors(
+                    "Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk."
+                  );
+                  console.error(error);
+                })
+                .finally(() => {
+                  setLoading(false);
+                });
+            })
+            .catch((error) => {
+              setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
 
-            setErrors(
-              "Unable to retrieve Service Config, Please try again or contact Helpdesk"
-            );
-            console.error(error);
-            setLoading(false);
-          });
+              setErrors(
+                "Unable to retrieve Service Config, Please try again or contact Helpdesk"
+              );
+              console.error(error);
+              setLoading(false);
+            });
+        } else {
+          fhirElmTranslationServiceApi
+            .then((fhirElmTranslationServiceApi) => {
+              fhirElmTranslationServiceApi
+                .getCqlBuilderLookups(measureStoreCql)
+                .then((axiosResponse: AxiosResponse<CqlBuilderLookup>) => {
+                  setCqlBuilderLookupsTypes(axiosResponse?.data);
+                })
+                .catch((error) => {
+                  setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
+
+                  setErrors(
+                    "Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk."
+                  );
+                  console.error(error);
+                })
+                .finally(() => {
+                  setLoading(false);
+                });
+            })
+            .catch((error) => {
+              setCqlBuilderLookupsTypes({} as unknown as CqlBuilderLookup);
+
+              setErrors(
+                "Unable to retrieve Service Config, Please try again or contact Helpdesk"
+              );
+              console.error(error);
+              setLoading(false);
+            });
+        }
       }
     } else {
       setLoading(false);
@@ -195,6 +203,7 @@ export default function CqlBuilderPanel({
               handleApplyLibrary={handleApplyLibrary}
               handleEditLibrary={handleEditLibrary}
               handleDeleteLibrary={handleDeleteLibrary}
+              hasCqlError={hasCqlError}
             />
           )}
           {activeTab === "valueSets" && (
@@ -214,6 +223,7 @@ export default function CqlBuilderPanel({
               setIsCQLUnchanged={setIsCQLUnchanged}
               isCQLUnchanged={isCQLUnchanged}
               handleApplyCode={handleApplyCode}
+              hasCqlError={hasCqlError}
             />
           )}
           {activeTab === "parameters" && (

--- a/src/CqlBuilderPanel/Includes/Includes.test.tsx
+++ b/src/CqlBuilderPanel/Includes/Includes.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import Includes from "./Includes";
 import userEvent from "@testing-library/user-event";
 import { mockServiceConfig } from "../../__mocks__/mockServiceConfig";
@@ -28,6 +28,7 @@ const props = {
   handleApplyLibrary: () => jest.fn(),
   handleEditLibrary: () => jest.fn(),
   handleDeleteLibrary: () => jest.fn(),
+  hasCqlError: false,
 };
 
 describe("Includes", () => {
@@ -46,5 +47,21 @@ describe("Includes", () => {
     await waitFor(() => {
       expect(savedLibraryTab).toHaveTextContent("Saved Libraries (1)");
     });
+  });
+
+  it("Should display not display included libraries when CQL has errors", async () => {
+    const newProps = { ...props, hasCqlError: true };
+    render(<Includes {...newProps} />);
+    userEvent.click(await screen.findByTestId("saved-libraries-tab"));
+
+    const savedLibrariesTable = await screen.findByTestId(
+      "library-results-tbl"
+    );
+    expect(savedLibrariesTable).toBeInTheDocument();
+    const tableBody = await screen.findByTestId("library-results-table-body");
+    expect(tableBody).toBeInTheDocument();
+    const visibleRows = await within(tableBody).findAllByRole("row");
+    expect(visibleRows).toHaveLength(1);
+    expect(visibleRows[0]).toHaveTextContent("No Results were found");
   });
 });

--- a/src/CqlBuilderPanel/Includes/Includes.tsx
+++ b/src/CqlBuilderPanel/Includes/Includes.tsx
@@ -15,6 +15,7 @@ interface IncludesProps {
   handleApplyLibrary: (library) => void;
   handleEditLibrary: (selectedLibrary, editedLibrary) => void;
   handleDeleteLibrary: (library) => void;
+  hasCqlError: boolean;
 }
 
 export default function Includes({
@@ -27,14 +28,17 @@ export default function Includes({
   handleApplyLibrary,
   handleEditLibrary,
   handleDeleteLibrary,
+  hasCqlError,
 }: IncludesProps) {
   const [activeLibraryTab, setActiveLibraryTab] = useState<string>("library");
   const [includedLibraryCount, setIncludedLibraryCount] = useState<number>(0);
 
   useEffect(() => {
-    if (cql) {
+    if (cql && !hasCqlError) {
       const count = new CqlAntlr(cql).parse().includes?.length;
       setIncludedLibraryCount(count || 0);
+    } else {
+      setIncludedLibraryCount(0);
     }
   }, [cql]);
 
@@ -66,6 +70,7 @@ export default function Includes({
           setEditorValue={setEditorValue}
           handleDeleteLibrary={handleDeleteLibrary}
           handleEditLibrary={handleEditLibrary}
+          hasCqlError={hasCqlError}
         />
       )}
     </div>

--- a/src/CqlBuilderPanel/Includes/SavedLibraryIncludes/SavedLibraryIncludes.tsx
+++ b/src/CqlBuilderPanel/Includes/SavedLibraryIncludes/SavedLibraryIncludes.tsx
@@ -23,6 +23,7 @@ interface PropTypes {
   setEditorValue: (cql) => void;
   handleDeleteLibrary: (library) => void;
   handleEditLibrary: (selectedLibrary, editedLibrary) => void;
+  hasCqlError: boolean;
 }
 
 const SavedLibraryIncludes = ({
@@ -34,6 +35,7 @@ const SavedLibraryIncludes = ({
   setEditorValue,
   handleDeleteLibrary,
   handleEditLibrary,
+  hasCqlError,
 }: PropTypes) => {
   const [libraries, setLibraries] = useState<CqlLibrary[]>([]);
   const libraryService = useRef(useCqlLibraryServiceApi());
@@ -104,8 +106,10 @@ const SavedLibraryIncludes = ({
   );
 
   useEffect(() => {
-    if (cql) {
+    if (cql && !hasCqlError) {
       fetchIncludedLibraries(cql);
+    } else {
+      setLibraries([]);
     }
   }, [cql, fetchIncludedLibraries]);
 

--- a/src/CqlBuilderPanel/codesSection/CodesSection.test.tsx
+++ b/src/CqlBuilderPanel/codesSection/CodesSection.test.tsx
@@ -1,15 +1,10 @@
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import * as React from "react";
 import CodesSection from "./CodesSection";
 import { useCodeSystems } from "./useCodeSystems";
 import { ServiceConfig } from "../../api/useServiceConfig";
 import { CodeSystem } from "../../api/useTerminologyServiceApi";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("./useCodeSystems");
 
@@ -72,7 +67,7 @@ mockUseCodeSystems.mockReturnValue({
 });
 const renderEditor = () => {
   // @ts-ignore: required props not required for tests
-  return render(<CodesSection canEdit={true} />);
+  return render(<CodesSection canEdit={true} hasCqlError={false} />);
 };
 
 describe("CodesSection", () => {
@@ -80,17 +75,11 @@ describe("CodesSection", () => {
     renderEditor();
     const code = await screen.findByTestId("code-tab");
     const savedCodes = await screen.findByText("Saved Codes(0)");
-
-    act(() => {
-      fireEvent.click(code);
-    });
+    userEvent.click(code);
     await waitFor(() => {
       expect(code).toHaveAttribute("aria-selected", "true");
     });
-
-    act(() => {
-      fireEvent.click(savedCodes);
-    });
+    userEvent.click(savedCodes);
     await waitFor(() => {
       expect(savedCodes).toHaveAttribute("aria-selected", "true");
     });
@@ -100,9 +89,7 @@ describe("CodesSection", () => {
     renderEditor();
     const codeSubTab = await screen.findByTestId("code-tab");
     expect(codeSubTab).toBeInTheDocument();
-    act(() => {
-      fireEvent.click(codeSubTab);
-    });
+    userEvent.click(codeSubTab);
     expect(codeSubTab).toHaveAttribute("aria-selected", "true");
 
     const codesSectionHeading = await screen.findByText("Code(s)");
@@ -117,9 +104,7 @@ describe("CodesSection", () => {
     renderEditor();
     const savedCodesSubTab = await screen.findByText("Saved Codes(0)");
     expect(savedCodesSubTab).toBeInTheDocument();
-    act(() => {
-      fireEvent.click(savedCodesSubTab);
-    });
+    userEvent.click(savedCodesSubTab);
     expect(savedCodesSubTab).toHaveAttribute("aria-selected", "true");
   });
 
@@ -139,13 +124,11 @@ describe("CodesSection", () => {
     );
     const savedCodesSubTab = await screen.findByText("Saved Codes(1)");
     expect(savedCodesSubTab).toBeInTheDocument();
-    act(() => {
-      fireEvent.click(savedCodesSubTab);
-    });
+    userEvent.click(savedCodesSubTab);
     expect(savedCodesSubTab).toHaveAttribute("aria-selected", "true");
   });
 
-  it("should render saved codes tab sectio with 0 saved code", async () => {
+  it("should render saved codes tab section with 0 saved code", async () => {
     render(
       <CodesSection
         canEdit={true}
@@ -161,9 +144,22 @@ describe("CodesSection", () => {
     );
     const savedCodesSubTab = await screen.findByText("Saved Codes(0)");
     expect(savedCodesSubTab).toBeInTheDocument();
-    act(() => {
-      fireEvent.click(savedCodesSubTab);
-    });
+    userEvent.click(savedCodesSubTab);
     expect(savedCodesSubTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("Should not render saved codes list when CQL has errors", async () => {
+    renderEditor();
+    const savedCodesSubTab = await screen.findByText("Saved Codes(0)");
+    expect(savedCodesSubTab).toBeInTheDocument();
+    userEvent.click(savedCodesSubTab);
+
+    const savedCodesTable = await screen.findByTestId("saved-codes-tbl");
+    expect(savedCodesTable).toBeInTheDocument();
+    const tableBody = await screen.findByTestId("saved-codes-tbl-body");
+    expect(tableBody).toBeInTheDocument();
+    const visibleRows = await within(tableBody).findAllByRole("row");
+    expect(visibleRows).toHaveLength(1);
+    expect(visibleRows[0]).toHaveTextContent("No Results were found");
   });
 });

--- a/src/CqlBuilderPanel/codesSection/CodesSection.tsx
+++ b/src/CqlBuilderPanel/codesSection/CodesSection.tsx
@@ -22,6 +22,7 @@ interface CodesSectionProps {
   setIsCQLUnchanged: Function;
   isCQLUnchanged: boolean;
   handleApplyCode;
+  hasCqlError?: boolean;
 }
 
 export default function CodesSection({
@@ -34,13 +35,14 @@ export default function CodesSection({
   setIsCQLUnchanged,
   isCQLUnchanged,
   handleApplyCode,
+  hasCqlError,
 }: CodesSectionProps) {
   const [activeTab, setActiveTab] = useState<string>("code");
   const { codeSystems } = useCodeSystems();
   const [parsedCodesList, setParsedCodesList] = useState<CodesList[]>(null);
 
   useEffect(() => {
-    if (measureStoreCql && !_.isEmpty(codeSystems)) {
+    if (measureStoreCql && !hasCqlError && !_.isEmpty(codeSystems)) {
       const parsedCql = new CqlAntlr(measureStoreCql).parse();
       if (!_.isEmpty(parsedCql?.codes)) {
         const codesList = parsedCql.codes.map((code) => {
@@ -101,6 +103,7 @@ export default function CodesSection({
             setIsCQLUnchanged={setIsCQLUnchanged}
             isCQLUnchanged={isCQLUnchanged}
             parsedCodesList={parsedCodesList}
+            hasCqlError={hasCqlError}
           />
         )}
       </div>

--- a/src/CqlBuilderPanel/codesSection/codesSubSection/savedCodesSubSection/SavedCodesSubSection.test.tsx
+++ b/src/CqlBuilderPanel/codesSection/codesSubSection/savedCodesSubSection/SavedCodesSubSection.test.tsx
@@ -1,11 +1,5 @@
 import * as React from "react";
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import SavedCodesSubSection, { CodesList } from "./SavedCodesSubSection";
 import { mockMeasureStoreCql } from "../../../__mocks__/MockMeasureStoreCql";
 import { TerminologyServiceApi } from "../../../../api/useTerminologyServiceApi";
@@ -91,6 +85,7 @@ describe("Saved Codes section component", () => {
         setIsCQLUnchanged={undefined}
         isCQLUnchanged={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
     expect(
@@ -147,6 +142,7 @@ describe("Saved Codes section component", () => {
         setIsCQLUnchanged={undefined}
         isCQLUnchanged={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
     expect(
@@ -204,6 +200,7 @@ describe("Saved Codes section component", () => {
         setIsCQLUnchanged={undefined}
         isCQLUnchanged={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
 
@@ -252,6 +249,7 @@ describe("Saved Codes section component", () => {
         setIsCQLUnchanged={undefined}
         isCQLUnchanged={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
 
@@ -293,6 +291,7 @@ describe("Saved Codes section component", () => {
         setIsCQLUnchanged={undefined}
         isCQLUnchanged={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
     await checkRows(3);
@@ -325,6 +324,7 @@ describe("Saved Codes section component", () => {
         setEditorVal={undefined}
         setIsCQLUnchanged={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
 
@@ -344,7 +344,7 @@ describe("Saved Codes section component", () => {
     expect(getByTestId("delete-dialog-continue-button")).toBeInTheDocument();
     expect(getByTestId("delete-dialog-cancel-button")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("delete-dialog-cancel-button"));
+    userEvent.click(getByTestId("delete-dialog-cancel-button"));
     await waitFor(() => {
       const submitButton = queryByText("Yes, Delete");
       expect(submitButton).not.toBeInTheDocument();
@@ -364,6 +364,7 @@ describe("Saved Codes section component", () => {
         setEditorVal={undefined}
         setIsCQLUnchanged={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
     await checkRows(3);
@@ -376,7 +377,7 @@ describe("Saved Codes section component", () => {
     expect(getByTestId("delete-dialog-continue-button")).toBeInTheDocument();
     expect(getByTestId("delete-dialog-cancel-button")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("delete-dialog-continue-button"));
+    userEvent.click(getByTestId("delete-dialog-continue-button"));
     expect(queryByTestId("delete-dialog-body")).toBeNull();
   });
 
@@ -392,6 +393,7 @@ describe("Saved Codes section component", () => {
         setIsCQLUnchanged={jest.fn()}
         handleApplyCode={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
     await checkRows(3);
@@ -404,13 +406,13 @@ describe("Saved Codes section component", () => {
     expect(getByTestId("discard-dialog-continue-button")).toBeInTheDocument();
     expect(getByTestId("discard-dialog-cancel-button")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("discard-dialog-continue-button"));
+    userEvent.click(getByTestId("discard-dialog-continue-button"));
 
     expect(getByTestId("delete-dialog")).toBeInTheDocument();
     expect(getByTestId("delete-dialog-continue-button")).toBeInTheDocument();
     expect(getByTestId("delete-dialog-cancel-button")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("delete-dialog-continue-button"));
+    userEvent.click(getByTestId("delete-dialog-continue-button"));
     expect(queryByTestId("delete-dialog-body")).toBeNull();
   });
 
@@ -426,6 +428,7 @@ describe("Saved Codes section component", () => {
         setIsCQLUnchanged={jest.fn()}
         handleApplyCode={undefined}
         parsedCodesList={parsedCodesList}
+        hasCqlError={false}
       />
     );
     await checkRows(3);
@@ -440,7 +443,7 @@ describe("Saved Codes section component", () => {
     const closeBtn = getByTestId("close-button");
     expect(closeBtn).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("discard-dialog-cancel-button"));
+    userEvent.click(getByTestId("discard-dialog-cancel-button"));
     expect(queryByTestId("delete-dialog")).not.toBeInTheDocument();
   });
 });

--- a/src/CqlBuilderPanel/codesSection/codesSubSection/savedCodesSubSection/SavedCodesSubSection.tsx
+++ b/src/CqlBuilderPanel/codesSection/codesSubSection/savedCodesSubSection/SavedCodesSubSection.tsx
@@ -87,6 +87,7 @@ export default function SavedCodesSubSection({
   setIsCQLUnchanged,
   isCQLUnchanged,
   parsedCodesList,
+  hasCqlError,
 }) {
   const [codes, setCodes] = useState<Code[]>();
   const [toastOpen, setToastOpen] = useState<boolean>(false);
@@ -134,7 +135,7 @@ export default function SavedCodesSubSection({
 
   //load codes when actual measure cql is changed
   useEffect(() => {
-    if (measureStoreCql && parsedCodesList?.length > 0) {
+    if (measureStoreCql && parsedCodesList?.length > 0 && !hasCqlError) {
       RetrieveCodeDetailsList(parsedCodesList);
     }
   }, [measureStoreCql]);

--- a/src/cqlEditorWithTerminology/CqlEditorWithTerminology.tsx
+++ b/src/cqlEditorWithTerminology/CqlEditorWithTerminology.tsx
@@ -41,6 +41,7 @@ const CqlEditorWithTerminology = ({
   isCQLUnchanged,
   resetCql,
   getCqlDefinitionReturnTypes,
+  hasCqlError,
 }: EditorPropsType) => {
   const [expanded, setExpanded] = useState(true);
   const toggleSearch = () => {
@@ -129,6 +130,7 @@ const CqlEditorWithTerminology = ({
               handleFunctionEdit={handleFunctionEdit}
               resetCql={resetCql}
               getCqlDefinitionReturnTypes={getCqlDefinitionReturnTypes}
+              hasCqlError={hasCqlError}
             />
           </Allotment.Pane>
         )}


### PR DESCRIPTION
…hen CQL has errors

## MADiE PR

Jira Ticket: [MAT-8215](https://jira.cms.gov/browse/MAT-8215)
(Optional) Related Tickets:

### Summary

1. When CQL Has errors, CQL UI builder is not populated with saved data
2. An error message should be displayed on top

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
